### PR TITLE
Mirror of signalapp Signal-Android#7468

### DIFF
--- a/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
+++ b/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
@@ -202,7 +202,7 @@ public class MessageRecipientListItem extends RelativeLayout
       mmsDatabase.removeFailure(record.getId(), failure);
 
       if (record.getRecipient().isPushGroupRecipient()) {
-        MessageSender.resendGroupMessage(context, record, failure.getAddress());
+        MessageSender.resendGroupMessage(context, record, failure == null ? null : failure.getAddress());
       } else {
         MessageSender.resend(context, record);
       }


### PR DESCRIPTION
Mirror of signalapp Signal-Android#7468
Fixes #7413

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
Virtual Nexus 6, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
It is possible when setting message indicators that a failed message will have an associated `NetworkFailure` object which has been set to null. If the failed message is a push group message and the NetworkFailure object is null, the eventual call to `getAddress()` during message send retry will throw a `NullPointerException`. This method call on a null NetworkFailure object is what caused the crash referenced in #7413. Instead of trying to get an address off of a null NetworkFailure, this change will set the address to null which will result in a failed send instead of an application crash.

This change was tested by forcing a null NetworkFailure to be created (hard-coded) during a retry of a group message. I first was able to re-create the crash, and then verify that the new changes averted the crash. I then tested that this change preserved normal functionality for an expected NetworkFailure by directing Signal to a bad server URL, forcing the retry button, and then retrying under normal network conditions for both individual and group messages.

